### PR TITLE
Feat/swg/customer type null

### DIFF
--- a/src/main/java/ga/backend/customer/controller/CustomerController.java
+++ b/src/main/java/ga/backend/customer/controller/CustomerController.java
@@ -32,8 +32,7 @@ public class CustomerController {
     public ResponseEntity postCustomer(@Valid @RequestBody CustomerRequestDto.Post post) {
         Customer customer = customerService.createCustomer(
                 customerMapper.customerPostDtoToCustomer(post),
-                post.getMetroGuDong(),
-                post.getCustomerTypePk()
+                post.getMetroGuDong()
         );
 
         CustomerResponseDto.Response response = customerMapper.customerToCustomerResponseDto(customer);

--- a/src/main/java/ga/backend/customer/mapper/CustomerMapper.java
+++ b/src/main/java/ga/backend/customer/mapper/CustomerMapper.java
@@ -8,6 +8,7 @@ import ga.backend.dong2.entity.Dong2;
 import ga.backend.gu2.entity.Gu2;
 import ga.backend.metro2.entity.Metro2;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -16,6 +17,7 @@ import java.util.stream.Collectors;
 
 @Mapper(componentModel = "spring")
 public interface CustomerMapper {
+    @Mapping(target = "customerType.pk", source = "customerTypePk")
     Customer customerPostDtoToCustomer(CustomerRequestDto.Post post);
 
     default List<Customer> customersPostDtoToCustomers(List<CustomerRequestDto.Post> posts) {

--- a/src/main/java/ga/backend/customer/service/CustomerService.java
+++ b/src/main/java/ga/backend/customer/service/CustomerService.java
@@ -84,7 +84,7 @@ public class CustomerService {
         List<CustomerType> customerTypes = customerTypeService.findCustomerTypeByCompanyFromEmployee(employee); // 고객의 customerType
 
         // NULL 유형의 고객유형
-        CustomerType nullCustomerType = customerTypes.stream().filter(c -> c.getName().equals("NULL")).findFirst().orElse(null);
+        CustomerType nullCustomerType = customerTypes.stream().filter(c -> c.getName().equals("000")).findFirst().orElse(null);
         if(nullCustomerType == null) nullCustomerType = customerTypeService.createNULLCustomerType(employee);
 
         for (int i = 0; i < customers.size(); i++) {
@@ -100,20 +100,24 @@ public class CustomerService {
 
             // customerType 설정
             String customerTypeName = customer.getCustomerType().getName();
-            CustomerType customerType = customerTypes.stream()
-                    .filter(c -> c.getName().equals(customerTypeName))
-                    .findFirst().orElse(null);
-            if(customerType == null) { // 없는 고객유형인 경우
+            CustomerType customerType;
+            if(customerTypeName == null) customerType = nullCustomerType;
+            else {
+                customerType = customerTypes.stream()
+                        .filter(c -> c.getName().equals(customerTypeName))
+                        .findFirst().orElse(null);
+                if(customerType == null) { // 없는 고객유형인 경우
 //                throw new BusinessLogicException(ExceptionCode.EMPLOYEE_AND_CUSTOMERTYPE_NOT_MATCH, "customerType is null { customer's name : " + customer.getName() + " }");
-                if(Pattern.matches("^[a-zA-Z0-9가-힣]{1,10}$", customerTypeName)) { // 생성가능한 이름인 경우
-                    // 새로운 고객유형 생성하기
-                    CustomerType newCustomerType = new CustomerType();
-                    newCustomerType.setName(customerTypeName);
-                    newCustomerType.setDataType(DataType.DB);
-                    customerType = customerTypeService.createCustomerType(newCustomerType);
-                } else {
-                    // 새로운 고객유형 생성하기 실패하면 default 고객유형으로 하기
-                    customerType = nullCustomerType;
+                    if(Pattern.matches("^[a-zA-Z0-9가-힣]{1,10}$", customerTypeName)) { // 생성가능한 이름인 경우
+                        // 새로운 고객유형 생성하기
+                        CustomerType newCustomerType = new CustomerType();
+                        newCustomerType.setName(customerTypeName);
+                        newCustomerType.setDataType(DataType.DB);
+                        customerType = customerTypeService.createCustomerType(newCustomerType);
+                    } else {
+                        // 새로운 고객유형 생성하기 실패하면 default 고객유형으로 하기
+                        customerType = nullCustomerType;
+                    }
                 }
             }
             customer.setCustomerType(customerType);

--- a/src/main/java/ga/backend/customer/service/CustomerService.java
+++ b/src/main/java/ga/backend/customer/service/CustomerService.java
@@ -290,12 +290,13 @@ public class CustomerService {
         return start;
     }
 
-    // 나이별 정렬(10, 20, 30, 40, 50, 60, 70, 80)
+    // 나이별 정렬(1020, 3040, 5060, 7080)
     public List<Customer> findCustomerByAge(String age, long customerTypePk) {
         Employee employee = findEmployee.getLoginEmployeeByToken();
         List<Customer> customers;
-        int start = returnAge(age);
-        int end = start + 9;
+        int start = Integer.parseInt(age)/100;
+        int end = start + 19;
+        System.out.println("!! start: " + start + ", end: " + end);
 
         if (customerTypePk == 0) { // 모든 고객유형 조회
             customers = customerRepository.findByEmployeeAndAgeBetweenAndDelYnFalseOrderByAge(
@@ -312,12 +313,12 @@ public class CustomerService {
         return customers;
     }
 
-    // 월별 나이별 정렬(10, 20, 30, 40, 50, 60, 70, 80)
+    // 월별 나이별 정렬(1020, 3040, 5060, 7080)
     public List<Customer> findCustomerByAge(String age, LocalDate date, long customerTypePk) {
         Employee employee = findEmployee.getLoginEmployeeByToken();
         List<Customer> customers = new ArrayList<>();
-        int ageStart = returnAge(age);
-        int ageEnd = ageStart + 9;
+        int ageStart = Integer.parseInt(age)/100;
+        int ageEnd = ageStart + 19;
 
         if (customerTypePk == 0) { // 모든 고객유형 조회
             List<CustomerType> customerTypes = customerTypeService.findCustomerTypeByCompanyFromEmployee(employee);
@@ -506,12 +507,12 @@ public class CustomerService {
         return customers;
     }
 
-    // 계약여부 정렬(나이대별)
+    // 계약여부 정렬(나이대별) - 1020, 3040, 5060, 7080
     public List<Customer> findCustomerByContractYnByLatest(boolean contractYn, String age, long customerTypePk) {
         Employee employee = findEmployee.getLoginEmployeeByToken();
         List<Customer> customers;
-        int ageStart = returnAge(age);
-        int ageEnd = ageStart + 9;
+        int ageStart = Integer.parseInt(age)/100;
+        int ageEnd = ageStart + 19;
 
         if (customerTypePk == 0) { // 모든 고객유형 조회
             customers = customerRepository.findByEmployeeAndContractYnAndAgeBetweenAndDelYnFalseOrderByAge(

--- a/src/main/java/ga/backend/customer/service/CustomerService.java
+++ b/src/main/java/ga/backend/customer/service/CustomerService.java
@@ -19,6 +19,7 @@ import ga.backend.metro2.entity.Metro2;
 import ga.backend.metro2.service.Metro2Service;
 import ga.backend.schedule.entity.Schedule;
 import ga.backend.customer.entity.ConsultationStatus;
+import ga.backend.util.CalculateAge;
 import ga.backend.util.FindCoordinateByKakaoMap;
 import ga.backend.util.FindEmployee;
 import ga.backend.util.InitialCustomerTypeNull;
@@ -70,6 +71,9 @@ public class CustomerService {
             throw new BusinessLogicException(ExceptionCode.EMPLOYEE_AND_CUSTOMERTYPE_NOT_MATCH);
         customer.setCustomerType(customerType);
 
+        // 만나이 계산
+        if(customer.getBirth() != null) customer.setAge(CalculateAge.getAge(customer.getBirth()));
+
         return customerRepository.save(customer);
     }
 
@@ -113,6 +117,9 @@ public class CustomerService {
                 }
             }
             customer.setCustomerType(customerType);
+
+            // 만나이 계산
+            if(customer.getBirth() != null) customer.setAge(CalculateAge.getAge(customer.getBirth()));
 
             customerRepository.save(customer);
         }
@@ -699,8 +706,12 @@ public class CustomerService {
         if (customerTypePk != null) findCustomer.setCustomerType(customerTypeService.findCustomerType(customerTypePk));
 
         Optional.ofNullable(customer.getName()).ifPresent(findCustomer::setName);
-        Optional.ofNullable(customer.getBirth()).ifPresent(findCustomer::setBirth);
         if (customer.getAge() != 0) findCustomer.setAge(customer.getAge());
+        Optional.ofNullable(customer.getBirth()).ifPresent(birth -> {
+            // 만나이 계산
+            findCustomer.setAge(CalculateAge.getAge(birth));
+            findCustomer.setBirth(birth);
+        });
         Optional.ofNullable(customer.getAddress()).ifPresent(findCustomer::setAddress);
         Optional.ofNullable(customer.getPhone()).ifPresent(findCustomer::setPhone);
         Optional.ofNullable(customer.getMemo()).ifPresent(findCustomer::setMemo);

--- a/src/main/java/ga/backend/customerType/dto/CustomerTypeRequestDto.java
+++ b/src/main/java/ga/backend/customerType/dto/CustomerTypeRequestDto.java
@@ -13,7 +13,7 @@ public class CustomerTypeRequestDto {
     @Getter
     public static class Post {
         private Long pk;
-        @Pattern(regexp = "^[a-zA-Z0-9]{1,10}$",
+        @Pattern(regexp = "^[a-zA-Z0-9가-힣]{1,10}$",
                 message = "영문자, 숫자로 설정 가능하며, 길이는 '최소 1자에서 최대 160'까지 허용")
         private String name; // 고객유형 이름
         private String color; // 색상
@@ -27,7 +27,7 @@ public class CustomerTypeRequestDto {
     @Getter
     public static class Patch {
         private Long pk;
-        @Pattern(regexp = "^[a-zA-Z0-9]{1,10}$",
+        @Pattern(regexp = "^[a-zA-Z0-9가-힣]{1,10}$",
                 message = "영문자, 숫자로 설정 가능하며, 길이는 '최소 1자에서 최대 160'까지 허용")
         private String name; // 고객유형 이름
         private String color; // 색상

--- a/src/main/java/ga/backend/customerType/entity/CustomerType.java
+++ b/src/main/java/ga/backend/customerType/entity/CustomerType.java
@@ -18,6 +18,9 @@ import java.util.List;
 @NoArgsConstructor
 @Getter
 @Setter
+@Table(name = "customer_type", uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"name", "company_pk"}) // 중복된 name이어도, 회사가 다르면 생성될 수 있도록 함
+})
 public class CustomerType extends Auditable {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -40,7 +43,7 @@ public class CustomerType extends Auditable {
     @Column
     private Long employeePk; // 관여한 사람
 
-    @Column(unique = true)
+    @Column
     private String name; // 고객유형 이름
 
     @Column

--- a/src/main/java/ga/backend/customerType/service/CustomerTypeService.java
+++ b/src/main/java/ga/backend/customerType/service/CustomerTypeService.java
@@ -46,6 +46,11 @@ public class CustomerTypeService {
     public CustomerType createCustomerType(CustomerType customerType) {
         customerType.setName(customerType.getName().toUpperCase()); // 고객유형 이름은 무조건 대문자만 허용
 
+        // NULL 이름의 default customerType 생성 불가능
+        if(customerType.getName().equals("NULL")) {
+            throw new BusinessLogicException(ExceptionCode.CUSTOMER_TYPE_NAME_NULL);
+        }
+
         Employee employee = findEmployee.getLoginEmployeeByToken();
         customerType.setEmployeePk(employee.getPk());
         customerType.setCompany(employee.getCompany());
@@ -89,20 +94,6 @@ public class CustomerTypeService {
     public List<CustomerType> findCustomerTypeByEmployee() {
         Employee employee = findEmployee.getLoginEmployeeByToken();
 
-        // "회사 && delYn=false"인 고객유형 조회
-        List<CustomerType> customerTypes = findCustomerTypeByCompanyFromEmployee(employee);
-
-        // hide에 있는 customerType -> 조회에 제외되어야 하는 것
-        List<CustomerType> hideCustomer = findCustomerTypeByHide(employee);
-
-        // hide에서 조회된 customerType 제외
-        customerTypes.removeAll(hideCustomer);
-
-        return customerTypes;
-    }
-
-    // 고객별 고객유형 조회
-    public List<CustomerType> findCustomerTypeByEmployee(Employee employee) {
         // "회사 && delYn=false"인 고객유형 조회
         List<CustomerType> customerTypes = findCustomerTypeByCompanyFromEmployee(employee);
 

--- a/src/main/java/ga/backend/customerType/service/CustomerTypeService.java
+++ b/src/main/java/ga/backend/customerType/service/CustomerTypeService.java
@@ -11,6 +11,7 @@ import ga.backend.exception.ExceptionCode;
 import ga.backend.hide.entity.Hide;
 import ga.backend.hide.repository.HideRepository;
 import ga.backend.util.FindEmployee;
+import ga.backend.util.InitialCustomerTypeNull;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -67,6 +68,11 @@ public class CustomerTypeService {
             else customerType.setColor(CustomerTypeColors.get(index+1));
         }
 
+        return customerTypeRepository.save(customerType);
+    }
+
+    public CustomerType createNULLCustomerType(Employee employee) {
+        CustomerType customerType = InitialCustomerTypeNull.makeCustomerType(employee);
         return customerTypeRepository.save(customerType);
     }
 

--- a/src/main/java/ga/backend/exception/BusinessLogicException.java
+++ b/src/main/java/ga/backend/exception/BusinessLogicException.java
@@ -11,7 +11,7 @@ public class BusinessLogicException extends RuntimeException {
 
     public BusinessLogicException(ExceptionCode exceptionCode) {
         super(exceptionCode.getMessage());
-        this.message = message;
+        this.message = exceptionCode.getMessage();
         this.exceptionCode = exceptionCode;
     }
 

--- a/src/main/java/ga/backend/exception/ExceptionCode.java
+++ b/src/main/java/ga/backend/exception/ExceptionCode.java
@@ -40,6 +40,7 @@ public enum ExceptionCode {
     FAIL_SEND_EMAIL(500, "Fail send email"),
 
     IMAGE_UPLOAD_FAIL(400, "이미지 업로드를 실패하였습니다."),
+    CUSTOMER_TYPE_NAME_NULL(403, "CustomerType's name can't NULL"),
     NOT_MATCH_AUTHNUM(400, "Not Match authNum");
 
 

--- a/src/main/java/ga/backend/util/CalculateAge.java
+++ b/src/main/java/ga/backend/util/CalculateAge.java
@@ -1,0 +1,14 @@
+package ga.backend.util;
+
+import java.time.LocalDate;
+import java.time.Period;
+
+// 만나이 구하기
+public class CalculateAge {
+    static public int getAge(LocalDate birthDate) {
+        LocalDate currentDate = LocalDate.now();
+
+        // 생년월일과 현재 날짜를 비교하여 나이 계산
+        return Period.between(birthDate, currentDate).getYears();
+    }
+}

--- a/src/main/java/ga/backend/util/InitialCustomerTypeNull.java
+++ b/src/main/java/ga/backend/util/InitialCustomerTypeNull.java
@@ -9,7 +9,7 @@ public class InitialCustomerTypeNull {
         CustomerType customerType = new CustomerType();
         customerType.setCompany(employee.getCompany());
         customerType.setEmployeePk(employee.getPk());
-        customerType.setName("NULL");
+        customerType.setName("000");
         customerType.setDetail("customerType을 지정하지 않을 경우 사용하는 default값");
         customerType.setDataType(DataType.ETC);
         customerType.setColor("#000000");

--- a/src/main/java/ga/backend/util/InitialCustomerTypeNull.java
+++ b/src/main/java/ga/backend/util/InitialCustomerTypeNull.java
@@ -1,0 +1,18 @@
+package ga.backend.util;
+
+import ga.backend.customerType.entity.CustomerType;
+import ga.backend.customerType.entity.DataType;
+import ga.backend.employee.entity.Employee;
+
+public class InitialCustomerTypeNull {
+    static public CustomerType makeCustomerType(Employee employee) {
+        CustomerType customerType = new CustomerType();
+        customerType.setCompany(employee.getCompany());
+        customerType.setEmployeePk(employee.getPk());
+        customerType.setName("NULL");
+        customerType.setDetail("customerType을 지정하지 않을 경우 사용하는 default값");
+        customerType.setDataType(DataType.ETC);
+        customerType.setColor("#000000");
+        return customerType;
+    }
+}


### PR DESCRIPTION
#178 
- 고객들 생성 시 고객유형 자동 등록하기
  - 고객들 생성 시 고객유형이 없으면 자동으로 새로운 고객유형(DB 유형) 생성 & 등록
  - 올바르지 않은 고객유형인 경우 -> NULL 고객유형으로 등록하기
  - 고객 유형
- customerType 이름은 NULL로 만들 수 없음
- customerType 이름 -> 한글, 영어, 숫자 가능(길이 : 1~10)
- 고객 생일을 통한 만나이 계산
- 나이별 정렬, 월별 나이별 정렬, 계약여부 정렬(나이별) 기준을 1020, 3040, 5060, 7080으로 변경
