### PR TITLE
Company & Analysis 기능 추가

### DIFF
--- a/src/main/java/ga/backend/analysis/dto/AnalysisResponseDto.java
+++ b/src/main/java/ga/backend/analysis/dto/AnalysisResponseDto.java
@@ -18,6 +18,7 @@ public class AnalysisResponseDto {
         private int dbCustomerCount; // 이번달에 추가된 customer 개수 - DB 고객유형
         private int etcCustomerCount; // 이번달에 추가된 customer 개수 - ETC 고객유형
         private CustomerConsultationRatio customerConsultationRatio; // customer의 상담현황 확률
+        private CustomerConsultationCount customerConsultationCount; // customer의 상담현황 개수
         private int contractCount; // Contract의 계약 체결한 Contract 개수
         private int contractYnCount; // 이번달에 계약을 체결한 Customer 개수
         private int asTargetCount; // Customer의 상담현황 = AS_TARGET인 Customer 개수
@@ -38,6 +39,19 @@ public class AnalysisResponseDto {
         private double medicalHistoryWaitingRatio; // 병력대기
         private double subscriptionRejectionRatio; // 청약거절
         private double consultationRejectionRatio; // 상담거절
+    }
+
+    // customer의 상담현황 개수
+    @AllArgsConstructor
+    @Setter
+    @Getter
+    public static class CustomerConsultationCount {
+        private int beforeConsultationCount; // 상담전
+        private int pendingCounsultationCount; // 상담보류중
+        private int productProposalCount; // 상품제안중
+        private int medicalHistoryWaitingCount; // 병력대기
+        private int subscriptionRejectionCount; // 청약거절
+        private int consultationRejectionCount; // 상담거절
     }
 
     // TA의 Customer 개수

--- a/src/main/java/ga/backend/analysis/entity/Analysis.java
+++ b/src/main/java/ga/backend/analysis/entity/Analysis.java
@@ -57,6 +57,25 @@ public class Analysis extends Auditable { // 성과분석
     @Column
     private double consultationRejectionRatio; // 상담거절
 
+    // customer의 상담현황 개수
+    @Column
+    private int beforeConsultationCount; // 상담전
+
+    @Column
+    private int pendingCounsultationCount; // 상담보류중
+
+    @Column
+    private int productProposalCount; // 상품제안중
+
+    @Column
+    private int medicalHistoryWaitingCount; // 병력대기
+
+    @Column
+    private int subscriptionRejectionCount; // 청약거절
+
+    @Column
+    private int consultationRejectionCount; // 상담거절
+
     // Contract의 계약 체결한 Contract 개수
     @Column
     private int contractCount;

--- a/src/main/java/ga/backend/analysis/mapper/AnalysisMapper.java
+++ b/src/main/java/ga/backend/analysis/mapper/AnalysisMapper.java
@@ -11,6 +11,7 @@ import java.util.List;
 @Mapper(componentModel = "spring")
 public interface AnalysisMapper {
     @Mapping(source = "analysis", target = "customerConsultationRatio")
+    @Mapping(source = "analysis", target = "customerConsultationCount")
     @Mapping(source = "analysis", target = "taCustomerCount")
     @Mapping(source = "analysis", target = "scheduleCount")
     AnalysisResponseDto.Response analysisToAnalysisResponseDto(Analysis analysis);

--- a/src/main/java/ga/backend/analysis/service/AnalysisService.java
+++ b/src/main/java/ga/backend/analysis/service/AnalysisService.java
@@ -123,8 +123,8 @@ public class AnalysisService {
                             employee, startDate, finishDate, customerType
                     ));
         else // ETC 고객유형
-            analysis.setEtcCustomerCount((
-                    int) customerRepository.countByEmployeeAndCreatedAtBetweenAndDelYnFalseAndCustomerType(
+            analysis.setEtcCustomerCount(
+                    (int) customerRepository.countByEmployeeAndCreatedAtBetweenAndDelYnFalseAndCustomerType(
                     employee, start, finish, customerType
             ));
 
@@ -154,7 +154,7 @@ public class AnalysisService {
         scheduleCustomerCount(analysis, employee, startDate, finishDate, customerType);
     }
 
-    // customer의 상담현황 확률
+    // customer의 상담현황 확률 & 개수
     public void consultationStatusRatio(Analysis analysis, Employee employee, LocalDateTime start, LocalDateTime finish, CustomerType customerType) {
         List<Customer> allCustomersByConsultationStatusModifiedAt = customerRepository.findByEmployeeAndConsultationStatusModifiedAtBetweenAndCustomerTypeAndDelYnFalse(
                 employee,
@@ -187,13 +187,25 @@ public class AnalysisService {
                 else if (customer.getConsultationStatus() == ConsultationStatus.CONSULTATION_REJECTION) consultationRejectionCount++;
                 else if (customer.getConsultationStatus() == ConsultationStatus.AS_TARGET) asTargetCount++;
             }
+
+            // customer의 상담현황 확률
             analysis.setBeforeConsultationRatio(beforeConsultationCount / allCustomerCount);
             analysis.setPendingCounsultationRatio(pendingConsultationCount / allCustomerCount);
             analysis.setProductProposalRatio(productProposalCount / allCustomerCount);
             analysis.setMedicalHistoryWaitingRatio(medicalHistoryWaitingCount / allCustomerCount);
             analysis.setSubscriptionRejectionRatio(subscriptionRejectionCount / allCustomerCount);
             analysis.setConsultationRejectionRatio(consultationRejectionCount / allCustomerCount);
-            analysis.setAsTargetCount(asTargetCount); // Customer의 상담현황 = AS_TARGET인 Customer 개수
+
+            // customer의 상담현황 개수
+            analysis.setBeforeConsultationCount(beforeConsultationCount);
+            analysis.setPendingCounsultationCount(pendingConsultationCount);
+            analysis.setProductProposalCount(productProposalCount);
+            analysis.setMedicalHistoryWaitingCount(medicalHistoryWaitingCount);
+            analysis.setSubscriptionRejectionCount(subscriptionRejectionCount);
+            analysis.setConsultationRejectionCount(consultationRejectionCount);
+
+            // Customer의 상담현황 = AS_TARGET인 Customer 개수
+            analysis.setAsTargetCount(asTargetCount);
         }
     }
 

--- a/src/main/java/ga/backend/company/repository/CompanyRepository.java
+++ b/src/main/java/ga/backend/company/repository/CompanyRepository.java
@@ -17,4 +17,6 @@ public interface CompanyRepository extends JpaRepository<Company, Long> {
     List<Company> findAllByDelYnAndPkAndName(boolean delYn, Long pk, String name);
     Optional<Company> findByDelYnFalseAndPk(long companyPk);
 
+    Optional<Company> findFirstByDelYnFalseAndName(String name);
+
 }

--- a/src/main/java/ga/backend/company/service/CompanyService.java
+++ b/src/main/java/ga/backend/company/service/CompanyService.java
@@ -63,4 +63,9 @@ public class CompanyService {
         Optional<Company> company = companyRespository.findByDelYnFalseAndPk(companyPk);
         return company.orElseThrow(() -> new BusinessLogicException(ExceptionCode.COMPANY_NOT_FOUND));
     }
+
+    // 이름으로 회사 찾기
+    public Optional<Company> findCompanyByName(String name) {
+        return companyRespository.findFirstByDelYnFalseAndName(name);
+    }
 }

--- a/src/main/java/ga/backend/customer/dto/CustomerResponseDto.java
+++ b/src/main/java/ga/backend/customer/dto/CustomerResponseDto.java
@@ -17,6 +17,7 @@ public class CustomerResponseDto {
     public static class Response {
         private Long pk;
         private CustomerType customerType; // 고객 유형
+        private long customerCount; // 고객 개수
         private String name; // 이름
         private LocalDate birth; // 생년월일
         private int age; // 나이
@@ -47,6 +48,7 @@ public class CustomerResponseDto {
     public static class MetroGuDongResponse {
         private Long pk;
         private CustomerType customerType; // 고객 유형
+        private long customerCount; // 고객 개수
         private String name; // 이름
         private LocalDate birth; // 생년월일
         private Integer age; // 나이
@@ -78,6 +80,7 @@ public class CustomerResponseDto {
     public static class CoordinateResponse {
         private Long pk;
         private CustomerType customerType; // 고객 유형
+        private long customerCount; // 고객 개수
         private String name; // 이름
         private LocalDate birth; // 생년월일
         private int age; // 나이

--- a/src/main/java/ga/backend/employee/service/EmployeeService.java
+++ b/src/main/java/ga/backend/employee/service/EmployeeService.java
@@ -41,21 +41,31 @@ public class EmployeeService {
         // 팀 연관관계 설정
         if(teamPk != 0) employee.setTeam(teamService.verifiedTeam(teamPk));
 
+//        System.out.println("@@companyName : " + companyName);
+//        System.out.println("@@companyName : " + companyName.equals(""));
+//        System.out.println("@@companyName : " + !companyName.equals(""));
+
         // 회사 연관관계 설정
         if(companyPk != null) employee.setCompany(companyService.verifiedCompany(companyPk));
-        else if(companyName != null) { // 사용자 설정으로 새로운 회사 생성하기
-            // 새로 회사를 생성
-            Company company = new Company();
-            company.setName(companyName);
-            company = companyService.createCompany(company);
-            employee.setCompany(company);
-        } else { // 회사PK와 회사이름이 없으면 자동으로 이름 생성
+        else if(companyName == null || companyName.equals("")) { // 회사PK와 회사이름이 없으면 자동으로 이름 생성
+            System.out.println("!!!!");
+
             // 새로 회사를 생성
             Company company = new Company();
             String autoCompanyName = "GA_" + employee.getEmail().split("@")[0];
             company.setName(autoCompanyName);
             company = companyService.createCompany(company);
             employee.setCompany(company);
+        } else { // 사용자 설정으로 새로운 회사 생성하기
+            // 기존에 같은 회사가 있는지 탐색
+            Optional<Company> findCompany = companyService.findCompanyByName(companyName);
+            if(findCompany.isPresent()) employee.setCompany(findCompany.get());
+            else { // 새로 회사를 생성
+                Company company = new Company();
+                company.setName(companyName);
+                company = companyService.createCompany(company);
+                employee.setCompany(company);
+            }
         }
 
         return employeeRespository.save(employee);


### PR DESCRIPTION
- #208
    - 회원가입 시 회사 연관관계 재설정
        - companyName이 Null이거나 ""일 경우에는 개인 GA 생성
        - companyName이 있는 경우, 존재하는 회사 이름인지 검색하고 있으면 연관관계 매핑하기
        - 만약 companyName가 없을 경우에는 새로운 회사 생성해서 연관관계 매핑하기
- #209 
    - anlaysis의 customer의 상담현황 개수 추가하기
        - entity에 anlaysis의 customer의 상담현황 개수 컬럼 추가
        - customer의 상담현황 확률에 사용하는 개수를 활용함